### PR TITLE
Add missing dependency to graphviz

### DIFF
--- a/recipe/0001-Detect-graphviz-executables-with-bat-extension.patch
+++ b/recipe/0001-Detect-graphviz-executables-with-bat-extension.patch
@@ -1,0 +1,51 @@
+From a6984512da91372bd07da50c1152b54d25e7f03d Mon Sep 17 00:00:00 2001
+From: Julien Schueller <schueller@phimeca.com>
+Date: Tue, 11 Dec 2018 14:09:38 +0100
+Subject: [PATCH] Detect graphviz executables with bat extension
+
+This is useful on conda where the executables are relocated with bat
+files.
+
+Fixes #14
+---
+ lib/pydotplus/graphviz.py | 24 +++++++++---------------
+ 1 file changed, 9 insertions(+), 15 deletions(-)
+
+diff --git a/lib/pydotplus/graphviz.py b/lib/pydotplus/graphviz.py
+index cd765dc..a8e803e 100644
+--- a/lib/pydotplus/graphviz.py
++++ b/lib/pydotplus/graphviz.py
+@@ -462,21 +462,15 @@ def __find_executables(path):
+             if progs[prg]:
+                 continue
+ 
+-            if os.path.exists(os.path.join(path, prg)):
+-                if was_quoted:
+-                    progs[prg] = '"' + os.path.join(path, prg) + '"'
+-                else:
+-                    progs[prg] = os.path.join(path, prg)
+-
+-                success = True
+-
+-            elif os.path.exists(os.path.join(path, prg + '.exe')):
+-                if was_quoted:
+-                    progs[prg] = '"' + os.path.join(path, prg + '.exe') + '"'
+-                else:
+-                    progs[prg] = os.path.join(path, prg + '.exe')
+-
+-                success = True
++            for ext in ['', '.exe', '.bat']:
++                if os.path.exists(os.path.join(path, prg + ext)):
++                    if was_quoted:
++                        progs[prg] = '"' + os.path.join(path, prg + ext) + '"'
++                    else:
++                        progs[prg] = os.path.join(path, prg + ext)
++
++                    success = True
++                    break
+ 
+     if success:
+         return progs
+-- 
+2.17.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ source:
   fn: pydotplus-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/p/pydotplus/pydotplus-{{ version }}.tar.gz
   md5: 0e2fc3dbdfd846819d4cd3769cb4595b
+  patches:
+    # https://github.com/carlos-jenkins/pydotplus/pull/18
+    - 0001-Detect-graphviz-executables-with-bat-extension.patch
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -20,10 +20,12 @@ requirements:
     - python
     - setuptools
     - pyparsing >=2.0.1
+    - graphviz
 
   run:
     - python
     - pyparsing >=2.0.1
+    - graphviz
 
 test:
   imports:


### PR DESCRIPTION
This is puzzling, why graphviz is not provided ?
This is clearly marked as a dependency: https://pypi.org/project/pydotplus/
